### PR TITLE
11.0 dev medical pos

### DIFF
--- a/cb_medical_pos/models/pos_config.py
+++ b/cb_medical_pos/models/pos_config.py
@@ -17,7 +17,8 @@ class PosConfig(models.Model):
 
     @api.model
     def _compute_session_prefix(self, prefix):
-        return prefix
+        range = '%(range_y)s/'
+        return '%s/%s' % (prefix, range)
 
     @api.model
     def _prepare_ir_session_sequence(self, prefix):
@@ -28,7 +29,9 @@ class PosConfig(models.Model):
         vals = {
             "name": "Pos Config " + prefix,
             "code": "pos.config - " + prefix,
-            "padding": 5,
+            "padding": 4,
+            "number_increment": 1,
+            "use_date_range": True,
             "prefix": self._compute_session_prefix(prefix),
             "company_id": False,
             "implementation": 'no_gap'

--- a/cb_medical_pos/views/pos_config_views.xml
+++ b/cb_medical_pos/views/pos_config_views.xml
@@ -11,6 +11,12 @@
                     <div class="o_setting_left_pane">
 
                     </div>
+                    <div class="o_setting_right_pane"
+                         attrs="{'invisible': [('session_sequence_id','!=',False)]}">
+                        <label for="session_sequence_prefix"
+                               string="Session sequence prefix"/>
+                        <field name="session_sequence_prefix"/>
+                    </div>
                     <div class="o_setting_right_pane">
                         <label for="session_sequence_id"
                                string="Session sequence"/>

--- a/cb_test/tests/test_cb.py
+++ b/cb_test/tests/test_cb.py
@@ -460,10 +460,12 @@ class TestCB(SavepointCase):
         self.pos_config = self.env['pos.config'].create(pos_vals)
         self.pos_config.write({'session_sequence_prefix': 'POS'})
         self.assertTrue(self.pos_config.session_sequence_id)
-        self.assertEqual(self.pos_config.session_sequence_id.prefix, 'POS')
+        self.assertEqual(self.pos_config.session_sequence_id.prefix,
+                         'POS/%(range_y)s/')
         self.pos_config.write({'session_sequence_prefix': 'PS'})
         self.assertTrue(self.pos_config.session_sequence_id)
-        self.assertEqual(self.pos_config.session_sequence_id.prefix, 'PS')
+        self.assertEqual(self.pos_config.session_sequence_id.prefix,
+                         'PS/%(range_y)s/')
         self.pos_config.open_session_cb()
         self.session = self.pos_config.current_session_id
         self.session.action_pos_session_open()

--- a/cb_test_invoicing/tests/test_cb.py
+++ b/cb_test_invoicing/tests/test_cb.py
@@ -144,10 +144,12 @@ class TestCBSale(TestCB):
         self.session.action_pos_session_close()
         self.pos_config.write({'session_sequence_prefix': 'POS'})
         self.assertTrue(self.pos_config.session_sequence_id)
-        self.assertEqual(self.pos_config.session_sequence_id.prefix, 'POS')
+        self.assertEqual(self.pos_config.session_sequence_id.prefix,
+                         'POS/%(range_y)s/')
         self.pos_config.write({'session_sequence_prefix': 'PS'})
         self.assertTrue(self.pos_config.session_sequence_id)
-        self.assertEqual(self.pos_config.session_sequence_id.prefix, 'PS')
+        self.assertEqual(self.pos_config.session_sequence_id.prefix,
+                         'PS/%(range_y)s/')
         self.pos_config.open_session_cb()
         self.assertTrue(self.session.request_group_ids)
         self.assertFalse(encounter.is_preinvoiced)


### PR DESCRIPTION

Adds the sequence prefix to the pos config:

![image](https://user-images.githubusercontent.com/7683926/50513323-6b6a9f80-0a97-11e9-90e1-fc85ac13690d.png)

And creates the sequences automatically based on the prefix using the rule <prefix><%(range_y)s/>
![image](https://user-images.githubusercontent.com/7683926/50513344-9228d600-0a97-11e9-9263-d2f91d34a1a8.png)


