### PR TITLE
[11.0][FIX] cb_holidays_minimum_days: Change variable name

### DIFF
--- a/cb_holidays_minimum_days/models/hr_holidays.py
+++ b/cb_holidays_minimum_days/models/hr_holidays.py
@@ -13,10 +13,9 @@ class HrHolidays(models.Model):
     def _compute_warning_minimum(self):
         for rec in self:
             rec.warning = False
-            min_days = rec.holiday_status_id.minimum_days
+            min_days = rec.holiday_status_id.minimum_time
             days_asking = rec.number_of_days_temp
-            if (rec.type == 'remove' and
-                    rec.holiday_status_id.minimum_days and days_asking):
+            if rec.type == 'remove' and rec.holiday_status_id.minimum_time:
                 if days_asking < min_days:
                     rec.warning_minimum = _(
                         'Warning: The number of days is less than the minimum'

--- a/cb_holidays_minimum_days/models/hr_holidays_status.py
+++ b/cb_holidays_minimum_days/models/hr_holidays_status.py
@@ -8,4 +8,4 @@ class HrHolidaysStatus(models.Model):
 
     _inherit = 'hr.holidays.status'
 
-    minimum_days = fields.Integer(string='Minimum Days')
+    minimum_time = fields.Integer(string='Minimum Days')

--- a/cb_holidays_minimum_days/tests/test_cb_holidays_minimum_days.py
+++ b/cb_holidays_minimum_days/tests/test_cb_holidays_minimum_days.py
@@ -13,7 +13,7 @@ class TestCbHolidaysMinimumDays(TransactionCase):
         })
         self.holiday_type = self.env['hr.holidays.status'].create({
             'name': 'Leave Type Test',
-            'minimum_days': 7,
+            'minimum_time': 7,
         })
         self.allocation = self.env['hr.holidays'].create({
             'name': 'Test',

--- a/cb_holidays_minimum_days/views/hr_holidays_views.xml
+++ b/cb_holidays_minimum_days/views/hr_holidays_views.xml
@@ -10,7 +10,7 @@
         <field name="inherit_id" ref="hr_holidays.edit_holiday_status_form" />
         <field name="arch" type="xml">
             <field name="limit" position="after">
-                <field name="minimum_days"/>
+                <field name="minimum_time"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Aprovecho que aún no lo estamos usando para cambiar el nombre de la variable. Esto lo hago porque en 12.0 este modulo se puede usar con dias y con horas.
`minimum_days` -> `minimum_time`