### PR TITLE
[11.0][FIX] Hide Information from employees res.partner

### DIFF
--- a/cb_hr_views/views/res_partner.xml
+++ b/cb_hr_views/views/res_partner.xml
@@ -24,6 +24,12 @@
                 <button name="action_open_related_employee" string="Related employee" icon="fa-user-tie" type="object"
                         attrs="{'invisible': [('has_employee', '=', False)]}"/>
             </xpath>
+            <xpath expr="//group/group[1]" position="attributes">
+                <attribute name="attrs">{'invisible': [('has_employee', '=', True)]}</attribute>
+            </xpath>
+            <xpath expr="//group/group[2]" position="attributes">
+                <attribute name="attrs">{'invisible': [('has_employee', '=', True)]}</attribute>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Al estar los datos relacionados, se podía ver información personal desde el menú de practitioners. Esto lo oculta. He editado la vista en producción para ocultarlo también mientras.