### PR TITLE
add l10n_es_mis_report_expand

### DIFF
--- a/l10n_es_mis_report_expand/README.rst
+++ b/l10n_es_mis_report_expand/README.rst
@@ -1,0 +1,30 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=========================
+L10n Es Mis Report Expand
+=========================
+
+Plantillas extendidas MIS Builder para informes contables españoles
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/{project_repo}/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Authors
+------------
+
+Eficent
+
+Contributors
+------------
+
+* Joan Sisquella <joan.sisquella@eficent.com>

--- a/l10n_es_mis_report_expand/__manifest__.py
+++ b/l10n_es_mis_report_expand/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2019 Eficent Business & IT Consult. Services
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'L10n Es Mis Report Expand',
+    'summary': """
+        Plantillas extendidas MIS Builder para informes contables españoles""",
+    'version': '11.0.1.0.0',
+    'license': 'AGPL-3',
+    'author': 'Eficent',
+    'website': 'https://github.com/OCA/l10n-spain',
+    'depends': [
+        "l10n_es_mis_report",
+    ],
+    'data': [
+        "data/mis_report_styles.xml",
+        "data/mis_report_balance_sme.xml",
+        'data/mis_report_pyg_sme.xml',
+    ],
+    'demo': [
+    ],
+}

--- a/l10n_es_mis_report_expand/data/mis_report_balance_sme.xml
+++ b/l10n_es_mis_report_expand/data/mis_report_balance_sme.xml
@@ -1,0 +1,2413 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+   <data>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_11100" model="mis.report.kpi">
+         <field name="expression">es11110+es11120+es11130</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11110" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">21</field>
+         <field name="name">es11110</field>
+         <field name="description">20. Inmovilizaciones intangibles</field>
+         <field name="expression">+bale[20%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+       <record id="mis_report_kpi_es_balance_pymes_11120" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">22</field>
+         <field name="name">es11120</field>
+         <field name="description">280. Amortización acumulada del inmovilizado intangible</field>
+         <field name="expression">+bale[280%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11130" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">23</field>
+         <field name="name">es11130</field>
+         <field name="description">290. Deterioro de valor del inmovilizado intangible</field>
+         <field name="expression">+bale[290%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_11200" model="mis.report.kpi">
+         <field name="expression">es11210+es11220+es11230+es11240</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11210" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">31</field>
+         <field name="name">es11210</field>
+         <field name="description">21. Inmovilizaciones materiales</field>
+         <field name="expression">+bale[21%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11220" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">32</field>
+         <field name="name">es11220</field>
+         <field name="description">281. Amortización acumulada del inmovilizado material</field>
+         <field name="expression">+bale[281%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11230" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">33</field>
+         <field name="name">es11230</field>
+         <field name="description">291. Deterioro de valor del inmovilizado material</field>
+         <field name="expression">+bale[291%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11240" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">34</field>
+         <field name="name">es11240</field>
+         <field name="description">23. Inmovilizaciones materiales en curso</field>
+         <field name="expression">+bale[23%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_11300" model="mis.report.kpi">
+         <field name="expression">es11310+es11320+es11310</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11310" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">41</field>
+         <field name="name">es11310</field>
+         <field name="description">22. Inversiones inmobiliarias</field>
+         <field name="expression">+bale[22%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+       <record id="mis_report_kpi_es_balance_pymes_11320" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">41</field>
+         <field name="name">es11320</field>
+         <field name="description">282. Amortización acumulada de las inversiones inmobiliarias</field>
+         <field name="expression">+bale[282%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+       <record id="mis_report_kpi_es_balance_pymes_11330" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">41</field>
+         <field name="name">es11330</field>
+         <field name="description">292. Deterioro de valor de las inversiones inmobiliarias</field>
+         <field name="expression">+bale[292%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_11400" model="mis.report.kpi">
+         <field name="expression">es11410+es11420+es11430+es11440+es11450+es11450+es11460+es11470+es11480+es11490+es114a0+es114b0+es114c0+es114d0+es114e0</field>
+         <field name="auto_expand_accounts">True</field>
+      </record>
+       <record id="mis_report_kpi_es_balance_pymes_11410" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">51</field>
+         <field name="name">es11410</field>
+         <field name="description">2403. Participaciones a largo plazo en empresas del grupo</field>
+         <field name="expression">+bale[2403%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11420" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">51</field>
+         <field name="name">es11420</field>
+         <field name="description">2404. Participaciones a largo plazo en empresas asociadas</field>
+         <field name="expression">+bale[2404%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11430" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">51</field>
+         <field name="name">es11430</field>
+         <field name="description">2413. Valores representativos de deuda a largo plazo de empresas del grupo</field>
+         <field name="expression">+bale[2413%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11440" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">51</field>
+         <field name="name">es11440</field>
+         <field name="description">2414. Valores representativos de deuda a largo plazo de empresas asociadas</field>
+         <field name="expression">+bale[2414%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11450" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">51</field>
+         <field name="name">es11450</field>
+         <field name="description">2423. Créditos a largo plazo a empresas del grupo</field>
+         <field name="expression">+bale[2423%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11460" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">51</field>
+         <field name="name">es11460</field>
+         <field name="description">2424. Créditos a largo plazo a empresas asociadas</field>
+         <field name="expression">+bale[2424%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11470" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">51</field>
+         <field name="name">es11470</field>
+         <field name="description">2493. Desembolsos pendientes sobre participaciones a largo plazo en empresas del grupo</field>
+         <field name="expression">+bale[2493%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11480" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">51</field>
+         <field name="name">es11480</field>
+         <field name="description">2494. Desembolsos pendientes sobre participaciones a largo plazo en empresas asociadas</field>
+         <field name="expression">+bale[2494%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11490" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">51</field>
+         <field name="name">es11490</field>
+         <field name="description">2933. Deterioro de valor de participaciones a largo plazo en empresas del grupo</field>
+         <field name="expression">+bale[2933%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_114a0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">51</field>
+         <field name="name">es114a0</field>
+         <field name="description">2934. Deterioro de valor de participaciones a largo plazo en empresas asociadas</field>
+         <field name="expression">+bale[2934%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_114b0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">51</field>
+         <field name="name">es114b0</field>
+         <field name="description">2943. Deterioro de valor de valores representativos de deuda a largo plazo de empresas del grupo</field>
+         <field name="expression">+bale[2943%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_114c0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">51</field>
+         <field name="name">es114c0</field>
+         <field name="description">2944. Deterioro de valor de valores representativos de deuda a largo plazo de empresas asociadas</field>
+         <field name="expression">+bale[2944%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_114d0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">51</field>
+         <field name="name">es114d0</field>
+         <field name="description">2953. Deterioro de valor de créditos a largo plazo a empresas del grupo</field>
+         <field name="expression">+bale[2953%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+       <record id="mis_report_kpi_es_balance_pymes_114e0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">51</field>
+         <field name="name">es114e0</field>
+         <field name="description">2954. Deterioro de valor de créditos a largo plazo a empresas asociadas</field>
+         <field name="expression">+bale[2954%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_11500" model="mis.report.kpi">
+         <field name="expression">es11510+es11520+es11530+es11540+es11550+es11560+es11570+es11580+es11590+es115a0+es115b0+es115c0+es115d0+es115e0+es115f0+es115g0+es115h0+es115i0+es115j0</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11510" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">61</field>
+         <field name="name">es11510</field>
+         <field name="description">2405. Participaciones a largo plazo en otras partes vinculadas</field>
+         <field name="expression">+bale[2405%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11520" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">61</field>
+         <field name="name">es11520</field>
+         <field name="description">2415. Valores representativos de deuda a largo plazo de otras partes vinculadas</field>
+         <field name="expression">+bale[2415%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11530" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">61</field>
+         <field name="name">es11530</field>
+         <field name="description">2425. Créditos a largo plazo a otras partes vinculadas</field>
+         <field name="expression">+bale[2425%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11540" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">61</field>
+         <field name="name">es11540</field>
+         <field name="description">2495. Desembolsos pendientes sobre participaciones a largo plazo en otras partes vinculadas</field>
+         <field name="expression">+bale[2495%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11550" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">61</field>
+         <field name="name">es11550</field>
+         <field name="description">250. Inversiones financieras a largo plazo en instrumentos de patrimonio</field>
+         <field name="expression">+bale[250%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11560" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">61</field>
+         <field name="name">es11560</field>
+         <field name="description">251. Valores representativos de deuda a largo plazo</field>
+         <field name="expression">+bale[251%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11570" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">61</field>
+         <field name="name">es11570</field>
+         <field name="description">252. Créditos a largo plazo</field>
+         <field name="expression">+bale[252%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11580" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">61</field>
+         <field name="name">es11580</field>
+         <field name="description">253. Créditos a largo plazo por enajenación de inmovilizado</field>
+         <field name="expression">+bale[253%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11590" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">61</field>
+         <field name="name">es11590</field>
+         <field name="description">254. Créditos a largo plazo al personal</field>
+         <field name="expression">+bale[254%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_115a0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">61</field>
+         <field name="name">es115a0</field>
+         <field name="description">255. Activos por derivados financieros a largo plazo</field>
+         <field name="expression">+bale[255%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_115b0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">61</field>
+         <field name="name">es115b0</field>
+         <field name="description">258. Imposiciones a largo plazo</field>
+         <field name="expression">+bale[258%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_115c0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">61</field>
+         <field name="name">es115c0</field>
+         <field name="description">259. Desembolsos pendientes sobre participaciones en el patrimonio neto a largo plazo"</field>
+         <field name="expression">+bale[259%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_115d0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">61</field>
+         <field name="name">es115d0</field>
+         <field name="description">26. Fianzas y depósitos constituidos a largo plazo</field>
+         <field name="expression">+bale[26%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_115e0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">61</field>
+         <field name="name">es115e0</field>
+         <field name="description">2935. Deterioro de valor de participaciones a largo plazo en otras partes vinculadas</field>
+         <field name="expression">+bale[2935%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_115f0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">61</field>
+         <field name="name">es115f0</field>
+         <field name="description">2945. Deterioro de valor de valores representativos de deuda a largo plazo de otras partes vinculadas</field>
+         <field name="expression">+bale[2945%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_115g0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">61</field>
+         <field name="name">es115g0</field>
+         <field name="description">2955. Deterioro de valor de créditos a largo plazo a otras partes vinculadas</field>
+         <field name="expression">+bale[2955%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_115h0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">61</field>
+         <field name="name">es115h0</field>
+         <field name="description">296. Deterioro de valor de participaciones en el patrimonio neto a largo plazo</field>
+         <field name="expression">+bale[296%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_115i0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">61</field>
+         <field name="name">es115i0</field>
+         <field name="description">297. Deterioro de valor de valores representativos de deuda a largo plazo</field>
+         <field name="expression">+bale[297%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_115j0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">61</field>
+         <field name="name">es115j0</field>
+         <field name="description">298. Deterioro de valor de créditos a largo plazo</field>
+         <field name="expression">+bale[298%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_12200" model="mis.report.kpi">
+         <field name="expression">es12210+es12220+es12230+es12240+es12250+es12260+es12270+es12280+es12290</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12210" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">101</field>
+         <field name="name">es12210</field>
+         <field name="description">30. Comerciales</field>
+         <field name="expression">+bale[30%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+       <record id="mis_report_kpi_es_balance_pymes_12220" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">101</field>
+         <field name="name">es12220</field>
+         <field name="description">31. Materias primas</field>
+         <field name="expression">+bale[31%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+       <record id="mis_report_kpi_es_balance_pymes_12230" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">101</field>
+         <field name="name">es12230</field>
+         <field name="description">32. Otros aprovisionamientos</field>
+         <field name="expression">+bale[32%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+       <record id="mis_report_kpi_es_balance_pymes_12240" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">101</field>
+         <field name="name">es12240</field>
+         <field name="description">33. Productos en curso</field>
+         <field name="expression">+bale[33%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+       <record id="mis_report_kpi_es_balance_pymes_12250" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">101</field>
+         <field name="name">es12250</field>
+         <field name="description">34. Productos semiterminados</field>
+         <field name="expression">+bale[34%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+       <record id="mis_report_kpi_es_balance_pymes_12260" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">101</field>
+         <field name="name">es12260</field>
+         <field name="description">35. Productos terminados</field>
+         <field name="expression">+bale[35%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+       <record id="mis_report_kpi_es_balance_pymes_12270" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">101</field>
+         <field name="name">es12270</field>
+         <field name="description">36. Subproductos, residuos y materiales recuperados</field>
+         <field name="expression">+bale[36%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+       <record id="mis_report_kpi_es_balance_pymes_12280" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">101</field>
+         <field name="name">es12280</field>
+         <field name="description">39. Deterioro de valor de las existencias</field>
+         <field name="expression">+bale[39%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+       <record id="mis_report_kpi_es_balance_pymes_12290" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">101</field>
+         <field name="name">es12290</field>
+         <field name="description">407. Anticipos a proveedores</field>
+         <field name="expression">+bale[407%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_12380" model="mis.report.kpi">
+         <field name="expression">es12383+es12384+es12385+es12386+es12387+es12388+es12389+es1238a+es1238b+es1238c +es12381 +es12382</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12383" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">121</field>
+         <field name="name">es12383</field>
+         <field name="description">430) Clientes</field>
+         <field name="expression">+bale[430%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12384" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">121</field>
+         <field name="name">es12384</field>
+         <field name="description">431) Clientes, efectos comerciales a cobrar</field>
+         <field name="expression">+bale[431%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12385" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">121</field>
+         <field name="name">es12385</field>
+         <field name="description">432) Clientes, operaciones de «factoring»</field>
+         <field name="expression">+bale[432%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12386" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">121</field>
+         <field name="name">es12386</field>
+         <field name="description">433) Clientes, empresas del grupo</field>
+         <field name="expression">+bale[433%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12387" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">121</field>
+         <field name="name">es12387</field>
+         <field name="description">434) Clientes, empresas asociadas</field>
+         <field name="expression">+bale[434%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12388" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">121</field>
+         <field name="name">es12388</field>
+         <field name="description">435) Clientes, otras partes vinculadas</field>
+         <field name="expression">+bale[435%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12389" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">121</field>
+         <field name="name">es12389</field>
+         <field name="description">436) Clientes de dudoso cobro</field>
+         <field name="expression">+bale[436%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_1238a" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">121</field>
+         <field name="name">es1238a</field>
+         <field name="description">437) Envases y embalajes a devolver por clientes</field>
+         <field name="expression">+bale[437%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_1238b" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">121</field>
+         <field name="name">es1238b</field>
+         <field name="description">490) Deterioro de valor de créditos por operaciones comerciales</field>
+         <field name="expression">+bale[490%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_1238c" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">121</field>
+         <field name="name">es1238c</field>
+         <field name="description">493) Deterioro de valor de créditos por operaciones comerciales con partes vinculadas</field>
+         <field name="expression">+bale[493%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_12390" model="mis.report.kpi">
+         <field name="expression">es12391+es12392+es12393+es12394+es12395+es12396+es12397</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12391" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">161</field>
+         <field name="name">es12391</field>
+         <field name="description">44) Deudores varios</field>
+         <field name="expression">+bale[44%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12392" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">161</field>
+         <field name="name">es12392</field>
+         <field name="description">460) Anticipos de remuneraciones</field>
+         <field name="expression">+bale[460%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12393" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">161</field>
+         <field name="name">es12393</field>
+         <field name="description">470) Hacienda Pública, deudora por diversos conceptos</field>
+         <field name="expression">+bale[470%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12394" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">161</field>
+         <field name="name">es12394</field>
+         <field name="description">471) Organismos de la Seguridad Social, deudores</field>
+         <field name="expression">+bale[471%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12395" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">161</field>
+         <field name="name">es12395</field>
+         <field name="description">472) Hacienda Pública, IVA soportado</field>
+         <field name="expression">+bale[472%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12396" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">161</field>
+         <field name="name">es12396</field>
+         <field name="description">473) Hacienda Pública, retenciones y pagos a cuenta</field>
+         <field name="expression">+bale[473%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12397" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">161</field>
+         <field name="name">es12397</field>
+         <field name="description">544) Créditos a corto plazo al personal</field>
+         <field name="expression">+bale[544%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_12400" model="mis.report.kpi">
+         <field name="expression">es12410+es12420+es12430+es12440+es12450+es12460+es12470+es12480+es12490+es124a0+es124b0+es124c0+es124d0+es124e0+es124f0+es124g0+es124h0+es124i0+es124j0+es124k0+es124l0+es124m0</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12410" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es12410</field>
+         <field name="description">5303. Participaciones a corto plazo, en empresas del grupo</field>
+         <field name="expression">+bale[5303%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12420" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es12420</field>
+         <field name="description">5304. Participaciones a corto plazo, en empresas asociadas</field>
+         <field name="expression">+bale[5304%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12430" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es12430</field>
+         <field name="description">5313. Valores representativos de deuda a corto plazo de empresas del grupo</field>
+         <field name="expression">+bale[5313%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12440" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es12440</field>
+         <field name="description">5314. Valores representativos de deuda a corto plazo de empresas asociadas</field>
+         <field name="expression">+bale[5314%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12450" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es12450</field>
+         <field name="description">5323. Créditos a corto plazo a empresas del grupo</field>
+         <field name="expression">+bale[5323%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12460" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es12460</field>
+         <field name="description">5324. Créditos a corto plazo a empresas asociadas</field>
+         <field name="expression">+bale[5324%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12470" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es12470</field>
+         <field name="description">5333. Intereses a corto plazo de valores representativos de deuda de empresas del grupo</field>
+         <field name="expression">+bale[5333%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12480" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es12480</field>
+         <field name="description">5334. Intereses a corto plazo de valores representativos de deuda de empresas asociadas</field>
+         <field name="expression">+bale[5334%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12490" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es12490</field>
+         <field name="description">5343. Intereses a corto plazo de créditos a empresas del grupo</field>
+         <field name="expression">+bale[5343%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_124a0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es124a0</field>
+         <field name="description">5344. Intereses a corto plazo de créditos a empresas asociadas</field>
+         <field name="expression">+bale[5344%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_124b0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es124b0</field>
+         <field name="description">5353. Dividendo a cobrar de empresas del grupo</field>
+         <field name="expression">+bale[5353%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_124c0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es124c0</field>
+         <field name="description">5354. Dividendo a cobrar de empresas asociadas</field>
+         <field name="expression">+bale[5354%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_124d0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es124d0</field>
+         <field name="description">5393. Desembolsos pendientes sobre participaciones a corto plazo en empresas del grupo</field>
+         <field name="expression">+bale[5393%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_124e0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es124e0</field>
+         <field name="description">5394. Desembolsos pendientes sobre participaciones a corto plazo en empresas asociadas</field>
+         <field name="expression">+bale[5394%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_124f0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es124f0</field>
+         <field name="description">5933. Deterioro de valor de participaciones a corto plazo en empresas del grupo</field>
+         <field name="expression">+bale[5933%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_124g0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es124g0</field>
+         <field name="description">5934. Deterioro de valor de participaciones a corto plazo en empresas asociadas</field>
+         <field name="expression">+bale[5934%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_124h0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es124h0</field>
+         <field name="description">5943. Deterioro de valor de valores representativos de deuda a corto plazo de empresas del grupo</field>
+         <field name="expression">+bale[5943%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_124i0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es124i0</field>
+         <field name="description">5944. Deterioro de valor de valores representativos de deuda a corto plazo de empresas asociadas</field>
+         <field name="expression">+bale[5944%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_124j0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es124j0</field>
+         <field name="description">5953. Deterioro de valor de créditos a corto plazo a empresas del grupo</field>
+         <field name="expression">+bale[5953%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_124k0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es124k0</field>
+         <field name="description">5954. Deterioro de valor de créditos a corto plazo a empresas asociadas</field>
+         <field name="expression">+bale[5954%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_124l0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es124l0</field>
+         <field name="description">5523. Cuenta corriente con empresas del grupo</field>
+         <field name="expression">+pbale[5523%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_124m0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es124m0</field>
+         <field name="description">5524. Cuenta corriente con empresas asociadas</field>
+         <field name="expression">+pbale[5524%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_12500" model="mis.report.kpi">
+         <field name="expression">es12510+es12520+es12530+es12540+es12550+es12560+es12570+es12580+es12590+es125a0+es125b0+es125c0+es125d0+es125e0+es125f0+es125g0+es125h0+es125i0+es125j0+es125k0+es125l0+es125m0+es125n0+es125o0+es125p0+es125q0+es125r0+es125s0+es125t0</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12510" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es12510</field>
+         <field name="description">5305. Participaciones a corto plazo, en otras partes vinculadas</field>
+         <field name="expression">+bale[5305%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12520" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es12520</field>
+         <field name="description">5315. Valores representativos de deuda a corto plazo de otras partes vinculadas</field>
+         <field name="expression">+bale[5315%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12530" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es12530</field>
+         <field name="description">5325. Créditos a corto plazo a otras partes vinculadas</field>
+         <field name="expression">+bale[5325%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12540" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es12540</field>
+         <field name="description">5335. Intereses a corto plazo de valores representativos de deuda de otras partes vinculadas</field>
+         <field name="expression">+bale[5335%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12550" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es12550</field>
+         <field name="description">5345. Intereses a corto plazo de créditos a otras partes vinculadas</field>
+         <field name="expression">+bale[5345%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12560" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es12560</field>
+         <field name="description">5355. Dividendo a cobrar de otras partes vinculadas</field>
+         <field name="expression">+bale[5355%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12570" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es12570</field>
+         <field name="description">5395. Desembolsos pendientes sobre participaciones a corto plazo en otras partes vinculadas</field>
+         <field name="expression">+bale[5395%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12580" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es12580</field>
+         <field name="description">540. Inversiones financieras a corto plazo en instrumentos de patrimonio</field>
+         <field name="expression">+bale[540%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12590" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es12590</field>
+         <field name="description">541. Valores representativos de deuda a corto plazo</field>
+         <field name="expression">+bale[541%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_125a0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es125a0</field>
+         <field name="description">542. Créditos a corto plazo</field>
+         <field name="expression">+bale[542%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_125b0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es125b0</field>
+         <field name="description">543. Créditos a corto plazo por enajenación de inmovilizado</field>
+         <field name="expression">+bale[543%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_125c0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es125c0</field>
+         <field name="description">545. Dividendo a cobrar</field>
+         <field name="expression">+bale[545%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_125d0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es125d0</field>
+         <field name="description">546. Intereses a corto plazo de valores representativos de deudas</field>
+         <field name="expression">+bale[546%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_125e0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es125e0</field>
+         <field name="description">547. Intereses a corto plazo de créditos</field>
+         <field name="expression">+bale[547%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_125f0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es125f0</field>
+         <field name="description">548. Imposiciones a corto plazo</field>
+         <field name="expression">+bale[548%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_125g0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es125g0</field>
+         <field name="description">549. Imposiciones a corto plazo</field>
+         <field name="expression">+bale[549%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_125h0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es125h0</field>
+         <field name="description">5590. Activos por derivados financieros a corto plazo, cartera de negociación</field>
+         <field name="expression">+bale[5590%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_125i0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es125i0</field>
+         <field name="description">565. Fianzas constituidas a corto plazo</field>
+         <field name="expression">+bale[565%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_125j0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es125j0</field>
+         <field name="description">566. Depósitos constituidos a corto plazo</field>
+         <field name="expression">+bale[566%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_125k0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es125k0</field>
+         <field name="description">5935. Deterioro de valor de participaciones a corto plazo en otras partes vinculadas</field>
+         <field name="expression">+bale[5935%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_125l0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es125l0</field>
+         <field name="description">5945. Deterioro de valor de valores representativos de deuda a corto plazo de otras partes vinculadas</field>
+         <field name="expression">+bale[5945%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_125m0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es125m0</field>
+         <field name="description">5955. Deterioro de valor de créditos a corto plazo a otras partes vinculadas</field>
+         <field name="expression">+bale[5955%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_125n0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es125n0</field>
+         <field name="description">596. Deterioro de valor de participaciones a corto plazo</field>
+         <field name="expression">+bale[596%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_125o0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es125o0</field>
+         <field name="description">597. Deterioro de valor de valores representativos de deuda a corto plazo</field>
+         <field name="expression">+pbale[597%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_125p0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es125p0</field>
+         <field name="description">598. Deterioro de valor de créditos a corto plazo</field>
+         <field name="expression">+bale[598%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_125q0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es125q0</field>
+         <field name="description">550. Titular de la explotación</field>
+         <field name="expression">+pbale[550%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_125r0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es125r0</field>
+         <field name="description">551. Cuenta corriente con socios y administradores</field>
+         <field name="expression">+pbale[551%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_125s0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es125s0</field>
+         <field name="description">554. Cuenta corriente con uniones temporales de empresas y comunidades de bienes</field>
+         <field name="expression">+pbale[554%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_125t0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es125t0</field>
+         <field name="description">5525. Cuenta corriente con otras partes vinculadas</field>
+         <field name="expression">+pbale[5525%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_12600" model="mis.report.kpi">
+         <field name="expression">es12610+es12620</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12610" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">191</field>
+         <field name="name">es12610</field>
+         <field name="description">480. Gastos anticipados</field>
+         <field name="expression">+bale[480%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12620" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">191</field>
+         <field name="name">es12620</field>
+         <field name="description">567. Intereses pagados por anticipado</field>
+         <field name="expression">+bale[567%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_21110" model="mis.report.kpi">
+         <field name="expression">es21111+es21112+es21113</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21111" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">251</field>
+         <field name="name">es21111</field>
+         <field name="description">100) Capital social</field>
+         <field name="expression">+bale[100%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21112" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">251</field>
+         <field name="name">es21112</field>
+         <field name="description">101) Fondo social</field>
+         <field name="expression">+bale[101%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21113" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">251</field>
+         <field name="name">es21113</field>
+         <field name="description">102) Capital</field>
+         <field name="expression">+bale[102%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_21120" model="mis.report.kpi">
+         <field name="expression">es21121+es21122</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21121" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">261</field>
+         <field name="name">es21121</field>
+         <field name="description">1030) Socios por desembolsos no exigidos, capital social</field>
+         <field name="expression">+bale[1030%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21122" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">261</field>
+         <field name="name">es21122</field>
+         <field name="description">1040) Socios por aportaciones no dinerarias pendientes, capital social</field>
+         <field name="expression">+bale[1040%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_21300" model="mis.report.kpi">
+         <field name="expression">es21310+es21320+es21330+es21340</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21310" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">281</field>
+         <field name="name">es21310</field>
+         <field name="description">112. Reserva legal</field>
+         <field name="expression">+bale[112%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21320" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">281</field>
+         <field name="name">es21320</field>
+         <field name="description">113. Reservas voluntarias</field>
+         <field name="expression">+bale[113%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21330" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">281</field>
+         <field name="name">es21330</field>
+         <field name="description">114. Reservas especiales</field>
+         <field name="expression">+bale[114%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21340" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">281</field>
+         <field name="name">es21340</field>
+         <field name="description">119. Diferencias por ajuste del capital a euros</field>
+         <field name="expression">+bale[119%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_21400" model="mis.report.kpi">
+         <field name="expression">es21410+es21420</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21410" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">291</field>
+         <field name="name">es21410</field>
+         <field name="description">108. Acciones o participaciones propias en situaciones especiales</field>
+         <field name="expression">+bale[108%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21420" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">291</field>
+         <field name="name">es21420</field>
+         <field name="description">109. Acciones o participaciones propias para reducción de capital</field>
+         <field name="expression">+bale[109%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_21500" model="mis.report.kpi">
+         <field name="expression">es21510+es21520</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21510" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">301</field>
+         <field name="name">es21510</field>
+         <field name="description">120. Remanente</field>
+         <field name="expression">+bale[120%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21520" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">301</field>
+         <field name="name">es21520</field>
+         <field name="description">121. Resultados negativos de ejercicios anteriores</field>
+         <field name="expression">+bale[121%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_23000" model="mis.report.kpi">
+         <field name="expression">-bale[130%,131%,132%]</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_23100" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">351</field>
+         <field name="name">es23100</field>
+         <field name="description">130. Subvenciones oficiales de capital</field>
+         <field name="expression">+bale[130%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_23200" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">351</field>
+         <field name="name">es23200</field>
+         <field name="description">131. Donaciones y legados de capital</field>
+         <field name="expression">+bale[131%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_23300" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">351</field>
+         <field name="name">es23300</field>
+         <field name="description">132. Otras subvenciones, donaciones y legados</field>
+         <field name="expression">+bale[132%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_31220" model="mis.report.kpi">
+         <field name="expression">es31221+es31222</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31221" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">391</field>
+         <field name="name">es31221</field>
+         <field name="description">1605) Deudas a largo plazo con otras entidades de crédito vinculadas</field>
+         <field name="expression">+bale[1605%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31222" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">391</field>
+         <field name="name">es31222</field>
+         <field name="description">170) Deudas a largo plazo con entidades de crédito</field>
+         <field name="expression">+bale[170%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_31230" model="mis.report.kpi">
+         <field name="expression">es31231+es31232</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31231" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">401</field>
+         <field name="name">es31231</field>
+         <field name="description">1625) Acreedores por arrendamiento financiero a largo plazo, otras partes vinculadas</field>
+         <field name="expression">+bale[1625%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31232" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">401</field>
+         <field name="name">es31232</field>
+         <field name="description">174) Acreedores por arrendamiento financiero a largo plazo</field>
+         <field name="expression">+bale[174%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_31290" model="mis.report.kpi">
+         <field name="expression">-bale[1615%,1635%,171%,172%,173%,175%,176%,177%,179%,180%,185%]</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31291" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">411</field>
+         <field name="name">es31291</field>
+         <field name="description">1615) Proveedores de inmovilizado a largo plazo, otras partes vinculadas</field>
+         <field name="expression">+bale[1615%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31292" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">411</field>
+         <field name="name">es31292</field>
+         <field name="description">1635) Otras deudas a largo plazo, con otras partes vinculadas</field>
+         <field name="expression">+bale[1635%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31293" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">411</field>
+         <field name="name">es31293</field>
+         <field name="description">171) Deudas a largo plazo</field>
+         <field name="expression">+bale[171%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31294" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">411</field>
+         <field name="name">es31294</field>
+         <field name="description">172) Deudas a largo plazo transformables en subvenciones, donaciones y legados</field>
+         <field name="expression">+bale[172%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31295" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">411</field>
+         <field name="name">es31295</field>
+         <field name="description">173) Proveedores de inmovilizado a largo plazo</field>
+         <field name="expression">+bale[173%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31296" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">411</field>
+         <field name="name">es31296</field>
+         <field name="description">175) Efectos a pagar a largo plazo</field>
+         <field name="expression">+bale[175%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31297" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">411</field>
+         <field name="name">es31297</field>
+         <field name="description">176) Pasivos por derivados financieros a largo plazo</field>
+         <field name="expression">+bale[176%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31298" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">411</field>
+         <field name="name">es31298</field>
+         <field name="description">177) Obligaciones y bonos</field>
+         <field name="expression">+bale[177%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31299" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">411</field>
+         <field name="name">es31299</field>
+         <field name="description">179) Deudas representadas en otros valores negociables</field>
+         <field name="expression">+bale[179%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_3129a" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">411</field>
+         <field name="name">es3129a</field>
+         <field name="description">180) Fianzas recibidas a largo plazo</field>
+         <field name="expression">+bale[180%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_3129b" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">411</field>
+         <field name="name">es3129b</field>
+         <field name="description">185) Depósitos recibidos a largo plazo</field>
+         <field name="expression">+bale[185%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_31300" model="mis.report.kpi">
+         <field name="expression">es31310+es31320+es31330+es31340+es31350+es31360+es31370+es31380</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31310" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">421</field>
+         <field name="name">es31310</field>
+         <field name="description">1603. Deudas a largo plazo con entidades de crédito, empresas del grupo</field>
+         <field name="expression">+bale[1603%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31320" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">421</field>
+         <field name="name">es31320</field>
+         <field name="description">1604. Deudas a largo plazo con entidades de crédito, empresas asociadas</field>
+         <field name="expression">+bale[1604%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31330" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">421</field>
+         <field name="name">es31330</field>
+         <field name="description">1613. Proveedores de inmovilizado a largo plazo, empresas del grupo</field>
+         <field name="expression">+bale[1613%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31340" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">421</field>
+         <field name="name">es31340</field>
+         <field name="description">1614. Proveedores de inmovilizado a largo plazo, empresas asociadas</field>
+         <field name="expression">+bale[1614%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31350" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">421</field>
+         <field name="name">es31350</field>
+         <field name="description">1623. Acreedores por arrendamiento financiero a largo plazo, empresas de grupo</field>
+         <field name="expression">+bale[1623%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31360" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">421</field>
+         <field name="name">es31360</field>
+         <field name="description">1624. Acreedores por arrendamiento financiero a largo plazo, empresas asociadas</field>
+         <field name="expression">+bale[1624%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31370" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">421</field>
+         <field name="name">es31370</field>
+         <field name="description">1633. Otras deudas a largo plazo, empresas del grupo</field>
+         <field name="expression">+bale[1633%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31380" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">421</field>
+         <field name="name">es31380</field>
+         <field name="description">1634. Otras deudas a largo plazo, empresas asociadas</field>
+         <field name="expression">+bale[1634%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_31700" model="mis.report.kpi">
+         <field name="expression">es31710+es31720</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31710" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">461</field>
+         <field name="name">es31710</field>
+         <field name="description">15. Deudas a largo plazo con características especiales</field>
+         <field name="expression">+bale[15%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31720" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">461</field>
+         <field name="name">es31720</field>
+         <field name="description">5585. Socios por desembolsos exigidos sobre acciones o participaciones consideradas como pasivos financieros</field>
+         <field name="expression">+bale[5585%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_32200" model="mis.report.kpi">
+         <field name="expression">es32210+es32220</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32210" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">481</field>
+         <field name="name">es32210</field>
+         <field name="description">499. Provisiones por operaciones comerciales</field>
+         <field name="expression">+bale[499%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32220" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">481</field>
+         <field name="name">es32220</field>
+         <field name="description">529. Provisiones a corto plazo</field>
+         <field name="expression">+bale[529%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_32320" model="mis.report.kpi">
+         <field name="expression">es32321+es32322+es32323</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32321" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">501</field>
+         <field name="name">es32321</field>
+         <field name="description">5105) Deudas a corto plazo con otras entidades de crédito vinculadas</field>
+         <field name="expression">+bale[5105%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32322" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">501</field>
+         <field name="name">es32322</field>
+         <field name="description">520) Deudas a corto plazo con entidades de crédito</field>
+         <field name="expression">+bale[520%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32323" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">501</field>
+         <field name="name">es32323</field>
+         <field name="description">527) Intereses a corto plazo de deudas con entidades de crédito</field>
+         <field name="expression">+bale[527%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_32330" model="mis.report.kpi">
+         <field name="expression">-bale[5125%,524%]</field>
+         <field name="auto_expand_accounts">True</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32331" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">511</field>
+         <field name="name">es32321</field>
+         <field name="description">5125) Acreedores por arrendamiento financiero a corto plazo, otras partes vinculadas</field>
+         <field name="expression">+bale[5125%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32332" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">511</field>
+         <field name="name">es32322</field>
+         <field name="description">524) Acreedores por arrendamiento financiero a corto plazo</field>
+         <field name="expression">+bale[524%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+<!--      <record id="mis_report_kpi_es_balance_pymes_32390" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">520</field>
+         <field name="name">es32390</field>
+         <field name="description">3. Otras deudas a corto plazo</field>
+         <field name="expression">-bale[1034%,1044%,190%,192%,194%,500%,505%,506%,509%,5115%,5135%,5145%,521%,522%,523%,525%,526%,528%,555%,5565%,5566%,5595%,560%,561%] - nbale[550%%] - nbale[551%] - nbale[554%] - nbale[5525%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>-->
+<!--      <record id="mis_report_kpi_es_balance_pymes_32400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">530</field>
+         <field name="name">es32400</field>
+         <field name="description">III. Deudas con empresas del grupo y asociadas a corto plazo</field>
+         <field name="expression">-bale[5103%,5104%,5113%,5114%,5123%,5124%,5133%,5134%,5143%,5144%,5563%,5564%] - nbale[5523%] - nbale[5524%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l3i"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"/>
+      </record>-->
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_32580" model="mis.report.kpi">
+         <field name="expression">es32583+es32584+es32585+es32586+es32587+es32588+ +es32581 +es32582</field>
+         <field name="auto_expand_accounts">True</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32583" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">541</field>
+         <field name="name">es32583</field>
+         <field name="description">400) Proveedores</field>
+         <field name="expression">+bale[400%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32584" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">541</field>
+         <field name="name">es32584</field>
+         <field name="description">401) Proveedores, efectos comerciales a pagar</field>
+         <field name="expression">+bale[401%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32585" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">541</field>
+         <field name="name">es32585</field>
+         <field name="description">403) Proveedores, empresas del grupo</field>
+         <field name="expression">+bale[403%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32586" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">541</field>
+         <field name="name">es32586</field>
+         <field name="description">404) Proveedores, empresas asociadas</field>
+         <field name="expression">+bale[404%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32587" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">541</field>
+         <field name="name">es32587</field>
+         <field name="description">405) Proveedores, otras partes vinculadas</field>
+         <field name="expression">+bale[405%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32588" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">541</field>
+         <field name="name">es32588</field>
+         <field name="description">406) Envases y embalajes a devolver a proveedores</field>
+         <field name="expression">+bale[406%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_32590" model="mis.report.kpi">
+         <field name="expression">es32591+es32592+es32593+es32594+es32595+es32596</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32591" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">581</field>
+         <field name="name">es32591</field>
+         <field name="description">41) Acreedores varios</field>
+         <field name="expression">+bale[41%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32592" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">581</field>
+         <field name="name">es32592</field>
+         <field name="description">438) Anticipos de clientes</field>
+         <field name="expression">+bale[438%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32593" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">581</field>
+         <field name="name">es32593</field>
+         <field name="description">465) Remuneraciones pendientes de pago</field>
+         <field name="expression">+bale[465%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32594" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">581</field>
+         <field name="name">es32594</field>
+         <field name="description">475) Hacienda Pública, acreedora por conceptos fiscales</field>
+         <field name="expression">+bale[475%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32595" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">581</field>
+         <field name="name">es32595</field>
+         <field name="description">476) Organismos de la Seguridad Social, acreedores</field>
+         <field name="expression">+bale[476%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32596" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">581</field>
+         <field name="name">es32596</field>
+         <field name="description">477) Hacienda Pública, IVA repercutido</field>
+         <field name="expression">+bale[477%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_32600" model="mis.report.kpi">
+         <field name="expression">es32610+es32620</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32610" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">591</field>
+         <field name="name">es32610</field>
+         <field name="description">485. Ingresos anticipados</field>
+         <field name="expression">+bale[485%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32620" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">591</field>
+         <field name="name">es32620</field>
+         <field name="description">568. Intereses cobrados por anticipado</field>
+         <field name="expression">+bale[568%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_balance_pymes_32700" model="mis.report.kpi">
+         <field name="expression">es32710+es32710+es32710+es32710+es32710</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32710" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">601</field>
+         <field name="name">es32710</field>
+         <field name="description">195. Acciones o participaciones emitidas consideradas como pasivos financieros</field>
+         <field name="expression">+bale[195%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32720" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">601</field>
+         <field name="name">es32720</field>
+         <field name="description">197. Suscriptores de acciones consideradas como pasivos financieros</field>
+         <field name="expression">+bale[197%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32730" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">601</field>
+         <field name="name">es32730</field>
+         <field name="description">199. Acciones o participaciones emitidas consideradas como pasivos financieros pendientes de inscripción</field>
+         <field name="expression">+bale[199%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32740" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">601</field>
+         <field name="name">es32740</field>
+         <field name="description">502. Acciones o participaciones emitidas consideradas como pasivos financieros</field>
+         <field name="expression">+bale[502%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32750" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">601</field>
+         <field name="name">es32750</field>
+         <field name="description">507. Dividendos de acciones o participaciones consideradas como pasivos financieros</field>
+         <field name="expression">+bale[507%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+   </data>
+</odoo>

--- a/l10n_es_mis_report_expand/data/mis_report_pyg_sme.xml
+++ b/l10n_es_mis_report_expand/data/mis_report_pyg_sme.xml
@@ -1,0 +1,1111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+   <data>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_pyg_pymes_40100" model="mis.report.kpi">
+         <field name="expression">es40110+es40120+es40130+es40140+es40150+es40160+es40170+es40180+es40190</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40110" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">11</field>
+         <field name="name">es40110</field>
+         <field name="description">700. Ventas de mercaderías</field>
+         <field name="expression">-balp[700%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40120" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">11</field>
+         <field name="name">es40120</field>
+         <field name="description">701. Ventas de productos terminados</field>
+         <field name="expression">-balp[701%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40130" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">11</field>
+         <field name="name">es40130</field>
+         <field name="description">702. Ventas de productos semiterminados</field>
+         <field name="expression">-balp[702%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40140" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">11</field>
+         <field name="name">es40140</field>
+         <field name="description">703. Ventas de subproductos y residuos</field>
+         <field name="expression">-balp[703%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40150" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">11</field>
+         <field name="name">es40150</field>
+         <field name="description">704. Ventas de envases y embalajes</field>
+         <field name="expression">-balp[704%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40160" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">11</field>
+         <field name="name">es40160</field>
+         <field name="description">705. Prestaciones de servicios</field>
+         <field name="expression">-balp[705%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40170" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">11</field>
+         <field name="name">es40170</field>
+         <field name="description">706. Descuentos sobre ventas por pronto pago</field>
+         <field name="expression">-balp[706%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40180" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">11</field>
+         <field name="name">es40180</field>
+         <field name="description">708. Devoluciones de ventas y operaciones similares</field>
+         <field name="expression">-balp[708%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40190" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">11</field>
+         <field name="name">es40190</field>
+         <field name="description">709. «Rappels» sobre ventas</field>
+         <field name="expression">-balp[709%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_pyg_pymes_40200" model="mis.report.kpi">
+         <field name="expression">es40210+es40220+es40230</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40210" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">21</field>
+         <field name="name">es40210</field>
+         <field name="description">6930. Pérdidas por deterioro de productos terminados y en curso de fabricación</field>
+         <field name="expression">-balp[6930%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40220" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">21</field>
+         <field name="name">es40220</field>
+         <field name="description">71. Variación de existencias</field>
+         <field name="expression">-balp[71%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40230" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">21</field>
+         <field name="name">es40230</field>
+         <field name="description">7930. Reversión del deterioro de productos terminados y en curso de fabricación</field>
+         <field name="expression">-balp[7930%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_pyg_pymes_40300" model="mis.report.kpi">
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_pyg_pymes_40400" model="mis.report.kpi">
+         <field name="expression">es40410+es40420+es40430+es40440+es40450+es40460+es40470+es40480+es40490+es404a0+es404b0+es404c0+es404d0+es404e0</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40410" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">41</field>
+         <field name="name">es40410</field>
+         <field name="description">600. Compras de mercaderías</field>
+         <field name="expression">-balp[600%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40420" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">41</field>
+         <field name="name">es40420</field>
+         <field name="description">601. Compras de materias primas</field>
+         <field name="expression">-balp[601%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40430" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">41</field>
+         <field name="name">es40430</field>
+         <field name="description">602. Compras de otros aprovisionamientos</field>
+         <field name="expression">-balp[602%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40440" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">41</field>
+         <field name="name">es40440</field>
+         <field name="description">606. Descuentos sobre compras por pronto pago</field>
+         <field name="expression">-balp[606%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40450" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">41</field>
+         <field name="name">es40450</field>
+         <field name="description">607. Trabajos realizados por otras empresas</field>
+         <field name="expression">-balp[607%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40460" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">41</field>
+         <field name="name">es40460</field>
+         <field name="description">608. Devoluciones de compras y operaciones similares</field>
+         <field name="expression">-balp[608%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40470" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">41</field>
+         <field name="name">es40470</field>
+         <field name="description">609. «Rappels» por compras</field>
+         <field name="expression">-balp[609%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40480" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">41</field>
+         <field name="name">es40480</field>
+         <field name="description">61. Variación de existencias</field>
+         <field name="expression">-balp[61%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40490" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">41</field>
+         <field name="name">es40490</field>
+         <field name="description">6931. Pérdidas por deterioro de mercaderías</field>
+         <field name="expression">-balp[6931%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_404a0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">41</field>
+         <field name="name">es404a0</field>
+         <field name="description">6932. Pérdidas por deterioro de materias primas</field>
+         <field name="expression">-balp[6932%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_404b0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">41</field>
+         <field name="name">es404b0</field>
+         <field name="description">6933. Pérdidas por deterioro de otros aprovisionamientos</field>
+         <field name="expression">-balp[6933%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_404c0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">41</field>
+         <field name="name">es404c0</field>
+         <field name="description">7931. Reversión del deterioro de mercaderías</field>
+         <field name="expression">-balp[7931%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_404d0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">41</field>
+         <field name="name">es404d0</field>
+         <field name="description">7932. Reversión del deterioro de materias primas</field>
+         <field name="expression">-balp[7932%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_404e0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">41</field>
+         <field name="name">es404e0</field>
+         <field name="description">7933. Reversión del deterioro de otros aprovisionamientos</field>
+         <field name="expression">-balp[7933%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_pyg_pymes_40500" model="mis.report.kpi">
+         <field name="expression">es40510+es40520+es40530</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40510" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">51</field>
+         <field name="name">es40510</field>
+         <field name="description">740. Subvenciones, donaciones y legados a la explotación</field>
+         <field name="expression">-balp[740%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40520" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">51</field>
+         <field name="name">es40520</field>
+         <field name="description">747. Otras subvenciones, donaciones y legados transferidos al resultado del ejercicio</field>
+         <field name="expression">-balp[747%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40530" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">51</field>
+         <field name="name">es40530</field>
+         <field name="description">75. Otros ingresos de gestión</field>
+         <field name="expression">-balp[75%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_pyg_pymes_40600" model="mis.report.kpi">
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_pyg_pymes_40700" model="mis.report.kpi">
+         <field name="expression">es40710+es40720+es40730+es40740+es40750+es40760+es40770+es40780+es40790</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40710" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">71</field>
+         <field name="name">es40710</field>
+         <field name="description">62. Servicios exteriores</field>
+         <field name="expression">-balp[62%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40720" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">71</field>
+         <field name="name">es40720</field>
+         <field name="description">631. Otros tributos</field>
+         <field name="expression">-balp[631%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40730" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">71</field>
+         <field name="name">es40730</field>
+         <field name="description">634. Ajustes negativos en la imposición indirecta</field>
+         <field name="expression">-balp[634%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40740" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">71</field>
+         <field name="name">es40740</field>
+         <field name="description">636. Devolución de impuestos</field>
+         <field name="expression">-balp[636%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40750" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">71</field>
+         <field name="name">es40750</field>
+         <field name="description">639. Ajustes positivos en la imposición indirecta</field>
+         <field name="expression">-balp[639%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40760" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">71</field>
+         <field name="name">es40760</field>
+         <field name="description">65. Otros gastos de gestión</field>
+         <field name="expression">-balp[65%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40770" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">71</field>
+         <field name="name">es40770</field>
+         <field name="description">694. Pérdidas por deterioro de créditos por operaciones comerciales</field>
+         <field name="expression">-balp[694%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40780" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">71</field>
+         <field name="name">es40780</field>
+         <field name="description">794. Reversión del deterioro de créditos por operaciones comerciales</field>
+         <field name="expression">-balp[794%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_40790" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">71</field>
+         <field name="name">es40790</field>
+         <field name="description">7954. Exceso de provisión por operaciones comerciales</field>
+         <field name="expression">-balp[7954%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_pyg_pymes_40800" model="mis.report.kpi">
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_pyg_pymes_40900" model="mis.report.kpi">
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_pyg_pymes_41000" model="mis.report.kpi">
+         <field name="expression">es41010+es41020+es41030</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41010" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">101</field>
+         <field name="name">es41010</field>
+         <field name="description">7951. Exceso de provisión para impuestos</field>
+         <field name="expression">-balp[7951%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41020" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">101</field>
+         <field name="name">es41020</field>
+         <field name="description">7952. Exceso de provisión para otras responsabilidades</field>
+         <field name="expression">-balp[7952%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41030" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">101</field>
+         <field name="name">es41030</field>
+         <field name="description">7955. Exceso de provisión para actuaciones medioambientales</field>
+         <field name="expression">-balp[7955%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_pyg_pymes_41100" model="mis.report.kpi">
+         <field name="expression">es41110+es41120+es41130+es41140+es41150+es41160+es41170+es41180+es41190+es411a0+es411b0</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41110" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">111</field>
+         <field name="name">es41110</field>
+         <field name="description">670. Pérdidas procedentes del inmovilizado intangible</field>
+         <field name="expression">-balp[670%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41120" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">111</field>
+         <field name="name">es41120</field>
+         <field name="description">671. Pérdidas procedentes del inmovilizado material</field>
+         <field name="expression">-balp[671%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41130" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">111</field>
+         <field name="name">es41130</field>
+         <field name="description">672. Pérdidas procedentes de las inversiones inmobiliarias</field>
+         <field name="expression">-balp[672%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41140" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">111</field>
+         <field name="name">es41140</field>
+         <field name="description">690. Pérdidas por deterioro del inmovilizado intangible</field>
+         <field name="expression">-balp[690%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41150" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">111</field>
+         <field name="name">es41150</field>
+         <field name="description">691. Pérdidas por deterioro del inmovilizado material</field>
+         <field name="expression">-balp[691%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41160" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">111</field>
+         <field name="name">es41160</field>
+         <field name="description">692. Pérdidas por deterioro de las inversiones inmobiliarias</field>
+         <field name="expression">-balp[692%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41170" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">111</field>
+         <field name="name">es41170</field>
+         <field name="description">770. Beneficios procedentes del inmovilizado intangible</field>
+         <field name="expression">-balp[770%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41180" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">111</field>
+         <field name="name">es41180</field>
+         <field name="description">771. Beneficios procedentes del inmovilizado material</field>
+         <field name="expression">-balp[771%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41190" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">111</field>
+         <field name="name">es41190</field>
+         <field name="description">790. Reversión del deterioro del inmovilizado intangible</field>
+         <field name="expression">-balp[790%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_411a0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">111</field>
+         <field name="name">es411a0</field>
+         <field name="description">791. Reversión del deterioro del inmovilizado material</field>
+         <field name="expression">-balp[791%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_411b0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">111</field>
+         <field name="name">es411b0</field>
+         <field name="description">792. Reversión del deterioro de las inversiones inmobiliarias</field>
+         <field name="expression">-balp[792%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_pyg_pymes_41300" model="mis.report.kpi">
+         <field name="expression">es41310+es41320</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41310" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">121</field>
+         <field name="name">es41310</field>
+         <field name="description">678. Gastos excepcionales</field>
+         <field name="expression">-balp[678%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+       <record id="mis_report_kpi_es_balance_pymes_41320" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">121</field>
+         <field name="name">es41320</field>
+         <field name="description">778. Ingresos excepcionales</field>
+         <field name="expression">-balp[778%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_pyg_pymes_41430" model="mis.report.kpi">
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_pyg_pymes_41490" model="mis.report.kpi">
+         <field name="expression">es41491+es41492+es41493+es41494</field>
+         <field name="auto_expand_accounts">False</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41491" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">161</field>
+         <field name="name">es41491</field>
+         <field name="description">760. Ingresos de participaciones en instrumentos de patrimonio</field>
+         <field name="expression">-balp[760%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41492" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">161</field>
+         <field name="name">es41492</field>
+         <field name="description">761. Ingresos de valores representativos de deuda</field>
+         <field name="expression">-balp[761%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41493" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">161</field>
+         <field name="name">es41493</field>
+         <field name="description">762. Ingresos de créditos</field>
+         <field name="expression">-balp[762%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41494" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">161</field>
+         <field name="name">es41494</field>
+         <field name="description">769. Otros ingresos financieros</field>
+         <field name="expression">-balp[769%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l6i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l5_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_pyg_pymes_41500" model="mis.report.kpi">
+         <field name="expression">es41510+es41520+es41530+es41540+es41550+es41560</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41510" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es41510</field>
+         <field name="description">660. Gastos financieros por actualización de provisiones</field>
+         <field name="expression">-balp[660%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41520" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es41520</field>
+         <field name="description">661. Intereses de obligaciones y bonos</field>
+         <field name="expression">-balp[661%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41530" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es41530</field>
+         <field name="description">662. Intereses de deudas</field>
+         <field name="expression">-balp[662%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41540" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es41540</field>
+         <field name="description">664. Gastos por dividendos de acciones o participaciones consideradas como pasivos financieros</field>
+         <field name="expression">-balp[664%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41550" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es41550</field>
+         <field name="description">665. Intereses por descuento de efectos y operaciones de «factoring»</field>
+         <field name="expression">-balp[665%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41560" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">171</field>
+         <field name="name">es41560</field>
+         <field name="description">669. Otros gastos financieros</field>
+         <field name="expression">-balp[669%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_pyg_pymes_41600" model="mis.report.kpi">
+         <field name="expression">es41610+es41620</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41610" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es41610</field>
+         <field name="description">663. Pérdidas por valoración de instrumentos financieros por su valor razonable</field>
+         <field name="expression">-balp[663%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41620" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">181</field>
+         <field name="name">es41620</field>
+         <field name="description">763. Beneficios por valoración de instrumentos financieros por su valor razonable</field>
+         <field name="expression">-balp[763%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_pyg_pymes_41700" model="mis.report.kpi">
+         <field name="expression">es41710+es41720</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41710" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">191</field>
+         <field name="name">es41710</field>
+         <field name="description">668. Diferencias negativas de cambio</field>
+         <field name="expression">-balp[668%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41720" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">191</field>
+         <field name="name">es41720</field>
+         <field name="description">768. Diferencias positivas de cambio</field>
+         <field name="expression">-balp[768%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_pyg_pymes_41800" model="mis.report.kpi">
+         <field name="expression">es41810+es41820+es41830+es41840+es41850+es41860+es41870+es41880+es41890+es418a0+es418b0+es418c0+es418d0+es418e0</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+       <record id="mis_report_kpi_es_balance_pymes_41810" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">201</field>
+         <field name="name">es41810</field>
+         <field name="description">666. Pérdidas en participaciones y valores representativos de deuda</field>
+         <field name="expression">-balp[666%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41820" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">201</field>
+         <field name="name">es41820</field>
+         <field name="description">667. Pérdidas de créditos no comerciales</field>
+         <field name="expression">-balp[667%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41830" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">201</field>
+         <field name="name">es41830</field>
+         <field name="description">673. Pérdidas procedentes de participaciones a largo plazo en partes vinculadas</field>
+         <field name="expression">-balp[673%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41840" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">201</field>
+         <field name="name">es41840</field>
+         <field name="description">675. Pérdidas por operaciones con obligaciones propias</field>
+         <field name="expression">-balp[675%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41850" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">201</field>
+         <field name="name">es41850</field>
+         <field name="description">696. Pérdidas por deterioro de participaciones y valores representativos de deuda a largo plazo</field>
+         <field name="expression">-balp[696%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41860" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">201</field>
+         <field name="name">es41860</field>
+         <field name="description">697. Pérdidas por deterioro de créditos a largo plazo</field>
+         <field name="expression">-balp[697%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41870" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">201</field>
+         <field name="name">es41870</field>
+         <field name="description">698. Pérdidas por deterioro de participaciones y valores representativos de deuda a corto plazo</field>
+         <field name="expression">-balp[698%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41880" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">201</field>
+         <field name="name">es41880</field>
+         <field name="description">699. Pérdidas por deterioro de créditos a corto plazo</field>
+         <field name="expression">-balp[699%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41890" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">201</field>
+         <field name="name">es41890</field>
+         <field name="description">766. Beneficios en participaciones y valores representativos de deuda</field>
+         <field name="expression">-balp[766%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_418a0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">201</field>
+         <field name="name">es418a0</field>
+         <field name="description">773. Beneficios procedentes de participaciones a largo plazo en partes vinculadas</field>
+         <field name="expression">-balp[773%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_418b0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">201</field>
+         <field name="name">es418b0</field>
+         <field name="description">775. Beneficios por operaciones con obligaciones propias</field>
+         <field name="expression">-balp[775%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_418c0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">201</field>
+         <field name="name">es418c0</field>
+         <field name="description">796. Reversión del deterioro de participaciones y valores representativos de deuda a largo plazo</field>
+         <field name="expression">-balp[796%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_418d0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">201</field>
+         <field name="name">es418d0</field>
+         <field name="description">797. Reversión del deterioro de créditos a largo plazo</field>
+         <field name="expression">-balp[797%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_418e0" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">201</field>
+         <field name="name">es418e0</field>
+         <field name="description">799. Reversión del deterioro de créditos a corto plazo</field>
+         <field name="expression">-balp[799%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="l10n_es_mis_report.mis_report_kpi_es_pyg_pymes_41900" model="mis.report.kpi">
+         <field name="expression">es41910+es41920+es41930+es41940</field>
+         <field name="auto_expand_accounts">False</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41910" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">231</field>
+         <field name="name">es41910</field>
+         <field name="description">6300. Impuesto corriente</field>
+         <field name="expression">-balp[6300%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41920" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">231</field>
+         <field name="name">es41920</field>
+         <field name="description">6301. Impuesto diferido</field>
+         <field name="expression">-balp[6301%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41930" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">231</field>
+         <field name="name">es41930</field>
+         <field name="description">633. Ajustes negativos en la imposición sobre beneficios</field>
+         <field name="expression">-balp[633%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_41940" model="mis.report.kpi">
+         <field name="report_id" ref="l10n_es_mis_report.mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">231</field>
+         <field name="name">es41940</field>
+         <field name="description">638. Ajustes positivos en la imposición sobre beneficios</field>
+         <field name="expression">-balp[638%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"/>
+         <field name="style_id" ref="l10n_es_mis_report_expand.mis_report_style_l10n_es_l4_expand"/>
+      </record>
+   </data>
+</odoo>

--- a/l10n_es_mis_report_expand/data/mis_report_styles.xml
+++ b/l10n_es_mis_report_expand/data/mis_report_styles.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 Eficent Business and IT Consulting Services, S.L.
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+  <data>
+
+    <record id="mis_report_style_l10n_es_l4_expand" model="mis.report.style">
+      <field name="name">l10n_es l4 expand</field>
+      <field name="indent_level_inherit" eval="0"/>
+      <field name="indent_level">2</field>
+      <field name="hide_empty_inherit" eval="0"/>
+      <field name="hide_empty" eval="1"/>
+    </record>
+
+    <record id="mis_report_style_l10n_es_l5_expand" model="mis.report.style">
+      <field name="name">l10n_es l5 expand</field>
+      <field name="indent_level_inherit" eval="0"/>
+      <field name="indent_level">3</field>
+      <field name="hide_empty_inherit" eval="0"/>
+      <field name="hide_empty" eval="1"/>
+    </record>
+
+    <record id="mis_report_style_l10n_es_l6_expand" model="mis.report.style">
+      <field name="name">l10n_es l6 expand</field>
+      <field name="indent_level_inherit" eval="0"/>
+      <field name="indent_level">4</field>
+      <field name="hide_empty_inherit" eval="0"/>
+      <field name="hide_empty" eval="1"/>
+    </record>
+
+  </data>
+</odoo>


### PR DESCRIPTION
Añade un nivel de expansión adicional a los informes contables españoles. Por ahora limitado al modelo de pérdidas y ganancias y balance de situación para PYMES.

![image](https://user-images.githubusercontent.com/7683926/67699239-1dbb0e00-f9ac-11e9-8f0f-3fb68b38da3e.png)
