### PR TITLE
[16.0][FIX] pos_safe_box: no let edit coins value when is already closed

### DIFF
--- a/pos_safe_box/views/pos_session_validation_views.xml
+++ b/pos_safe_box/views/pos_session_validation_views.xml
@@ -73,7 +73,10 @@
                     </group>
                     <notebook>
                         <page string="Coins" id="line">
-                            <field name="line_ids" />
+                            <field
+                                name="line_ids"
+                                attrs="{'readonly': [('state', 'not in', ['draft'])]}"
+                            />
                         </page>
                         <page string="Sessions" id="pos_session">
                             <field


### PR DESCRIPTION
Aun dejaba modificar el valor de las monedas una vez cerrada la sesión. Arreglado en produccion.