### PR TITLE
[16.0] [FIX] cb_mgmtsystem_issue: fix description field display

### DIFF
--- a/cb_mgmtsystem_issue/views/mgmtsystem_nonconformity.xml
+++ b/cb_mgmtsystem_issue/views/mgmtsystem_nonconformity.xml
@@ -36,14 +36,6 @@
             <field name="system_id" position="attributes">
                 <attribute name="invisible">1</attribute>
             </field>
-            <field name="description" position="attributes">
-                <attribute name="invisible">1</attribute>
-            </field>
-            <field name="description" position="after">
-                <group>
-                    <field name="description" nolabel="1" />
-                </group>
-            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Before:
<img width="1110" height="369" alt="image" src="https://github.com/user-attachments/assets/a622d928-0bd1-44aa-bc9e-8a7013b50fe2" />

After:
<img width="1110" height="337" alt="image" src="https://github.com/user-attachments/assets/565a6adc-3ee3-4f3d-b0f3-48954a6c9d9a" />
